### PR TITLE
Fix -1 array bug

### DIFF
--- a/Firmware/OpeNITHM/OpeNITHM.ino
+++ b/Firmware/OpeNITHM/OpeNITHM.ino
@@ -253,7 +253,8 @@ void loop() {
       }
 
 #ifdef KEY_DIVIDERS     
-      leds[(index * 2) - 1] = divider_color;
+      if (index != 0)
+        leds[(index * 2) - 1] = divider_color;
 #endif
 
       updateLeds = true;  


### PR DESCRIPTION
Key 30 was being pressed every loop, making it stuck. The key divider code was accessing a negative array, overwriting other variables, causing this.