### PR TITLE
Fix for two finger presses not working on 16k.

### DIFF
--- a/Firmware/OpeNITHM/AutoTouchboard.cpp
+++ b/Firmware/OpeNITHM/AutoTouchboard.cpp
@@ -97,10 +97,19 @@ KeyState AutoTouchboard::update(int key) {
     } else if (pressure > triggerThresholdsSingle[key]) {
       states[key] = SINGLE_PRESS;
     }
-  // new release detected
-  } else if (states[key] != UNPRESSED) {
+  } else if (states[key] == SINGLE_PRESS) {
+    // going from single -> double
+    if (pressure > triggerThresholdsDouble[key]) {
+      states[key] = DOUBLE_PRESS;
+    // releasing single
+    } else if (pressure < releaseThresholdsSingle[key]) {
+      states[key] = UNPRESSED;
+    }
+  } else if (states[key] == DOUBLE_PRESS) {
+    // releasing completely
     if (pressure < releaseThresholdsSingle[key]) {
       states[key] = UNPRESSED;
+    // going from double -> single
     } else if (pressure < releaseThresholdsDouble[key]) {
       states[key] = SINGLE_PRESS;
     }

--- a/Firmware/OpeNITHM/AutoTouchboard.h
+++ b/Firmware/OpeNITHM/AutoTouchboard.h
@@ -32,7 +32,7 @@ class AutoTouchboard {
     int deltaThreshold = 5;
     double releaseThreshold = 0.8;
 #else
-    int deltaThreshold = 6;
+    int deltaThreshold = 15;
     double releaseThreshold = 0.8;
 #endif
     


### PR DESCRIPTION
Before, if a key was already being pressed, it would not check for increased pressure to go from single to double press.
Now if the key is currently single pressed, it checks if the threshold for double press has been passed.
The delta threshold for 16k has also been increased, as the previous one was too low and was giving double press even for only one finger.