### PR TITLE
Preliminary Big Board V2 changes

### DIFF
--- a/Firmware/OpeNITHM/AutoTouchboard.cpp
+++ b/Firmware/OpeNITHM/AutoTouchboard.cpp
@@ -1,7 +1,7 @@
 #include "AutoTouchboard.h"
 
 #if NUM_SENSORS == 32
-#ifndef OPENITHM_FULL_V1_0
+#ifndef ALT_TOUCHKEY_ORDER
 static const int sensorMap[] = {
   11, 3, 10, 2, 9, 1, 8, 0,
   31, 23, 30, 22, 29, 21, 28, 20,

--- a/Firmware/OpeNITHM/Config.h
+++ b/Firmware/OpeNITHM/Config.h
@@ -13,7 +13,8 @@
 // #define OPENITHM_V1_1   // Version 1.1 (v1.1 on board under logo)
 // #define OPENITHM_V2_0   // Version 2.0 (v2.0 in upper left of board)
 // #define OPENITHM_V2_1   // Version 2.1 (v2.1 in upper left of board)
-// #define OPENITHM_FULL_V1_0 // Version 1.0 of the fully integrated board with touch sensors
+// #define OPENITHM_FULL_V1_0 // Version 1.0 of the fully integrated board with touch sensors (Not common)
+ #define OPENITHM_FULL_V2_0 // Version 2.0 of the fully integrated board with touch sensors (Integrated USB C Port)
 
 // Uncomment this line if your IR sensors will be used in analog mode
 // ** OPENITHM_V1_1 AND ABOVE SHOULD ENABLE THIS OPTION **
@@ -72,17 +73,25 @@
 #define USB
 
 // Spit out errors for board definitions
-#if (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0)) == 0
+#if (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0) + defined(OPENITHM_FULL_V2_0)) == 0
 #error "Must define ONE Teensy board in Config.h"
-#elif (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0)) > 1
+#elif (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0) + defined(OPENITHM_FULL_V2_0)) > 1
 #error "Cannot define multiple Teensy boards in Config.h"
 #endif
 #endif
 
-#if (defined(OPENITHM_V2_0) || defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0))
+#if (defined(OPENITHM_V2_0) || defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL_V2_0))
 #define NUM_SENSORS  32
 #else
 #define NUM_SENSORS  16
+#endif
+
+#if (defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL_V2_0))
+#define ALT_TOUCHKEY_ORDER
+#endif
+
+#if defined(OPENITHM_FULL_V2_0)
+#define ALTERNATING_AIR
 #endif
 
 #endif // _CONFIG_h

--- a/Firmware/OpeNITHM/PinConfig.h
+++ b/Firmware/OpeNITHM/PinConfig.h
@@ -24,6 +24,10 @@
 #define MUX_0 4
 #define MUX_1 3
 #define MUX_2 2
+#elif defined(OPENITHM_FULL_V2_0)
+#define MUX_0 7
+#define MUX_1 6
+#define MUX_2 2
 #endif
 
 // Sensor pin settings
@@ -39,6 +43,13 @@
 #define LED_0 8
 #define LED_1 7
 #define LED_2 6
+#elif defined(OPENITHM_FULL_V2_0)
+#define LED_0 14
+#define LED_1 13
+#define LED_2 15
+#define LED_3 26
+#define LED_4 16
+#define LED_5 12
 #endif
 
 #ifdef IR_SENSOR_MULTIPLEXED
@@ -65,6 +76,13 @@
 #define AIR_SENSOR_3_PIN 19
 #define AIR_SENSOR_4_PIN 21
 #define AIR_SENSOR_5_PIN 23
+#elif defined(OPENITHM_FULL_V2_0)
+#define AIR_SENSOR_0_PIN 18
+#define AIR_SENSOR_1_PIN 23
+#define AIR_SENSOR_2_PIN 19
+#define AIR_SENSOR_3_PIN 22
+#define AIR_SENSOR_4_PIN 20
+#define AIR_SENSOR_5_PIN 21
 #endif
 #endif
 
@@ -90,6 +108,11 @@
 #define TOUCH_1 15
 #define TOUCH_2 16
 #define TOUCH_3 0
+#elif defined(OPENITHM_FULL_V2_0)
+#define TOUCH_0 0
+#define TOUCH_1 4
+#define TOUCH_2 3
+#define TOUCH_3 1
 #endif
 
 // Lighting pin settings
@@ -109,7 +132,7 @@
     #else
        #define RGBPIN 11
     #endif
-#elif defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0)
+#elif defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL_V2_0)
   #define RGBPIN 5
 #endif
 


### PR DESCRIPTION
Sets up Pin Defines for the big board. 
NOTE: Defining the new V2 board as is will not work until alternating air sensors are implemented, since it only has support for alternating air boards.