### PR TITLE
More big board support

### DIFF
--- a/Firmware/OpeNITHM/AutoTouchboard.cpp
+++ b/Firmware/OpeNITHM/AutoTouchboard.cpp
@@ -1,12 +1,19 @@
 #include "AutoTouchboard.h"
 
 #if NUM_SENSORS == 32
-#ifndef ALT_TOUCHKEY_ORDER
+#if (defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL2_0_UP))
 static const int sensorMap[] = {
   11, 3, 10, 2, 9, 1, 8, 0,
   31, 23, 30, 22, 29, 21, 28, 20,
   27, 19, 26, 18, 25, 17, 24, 16,
   15, 7, 14, 6, 13, 5, 12, 4
+};
+#elif defined(OPENITHM_FULL2_0_SIDE)
+static const int sensorMap[] = {
+  0, 8, 1, 9, 2, 10, 3, 11,
+  20, 28, 21, 29, 22, 30, 23, 31,
+  16, 24, 17, 25, 18, 26, 19, 27,
+  4, 12, 5, 13, 6, 14, 7, 15
 };
 #else
  static const int sensorMap[] = {

--- a/Firmware/OpeNITHM/AutoTouchboard.cpp
+++ b/Firmware/OpeNITHM/AutoTouchboard.cpp
@@ -3,24 +3,25 @@
 #if NUM_SENSORS == 32
 #if (defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL2_0_UP))
 static const int sensorMap[] = {
-  11, 3, 10, 2, 9, 1, 8, 0,
-  31, 23, 30, 22, 29, 21, 28, 20,
-  27, 19, 26, 18, 25, 17, 24, 16,
-  15, 7, 14, 6, 13, 5, 12, 4
-};
-#elif defined(OPENITHM_FULL2_0_SIDE)
-static const int sensorMap[] = {
-  0, 8, 1, 9, 2, 10, 3, 11,
-  20, 28, 21, 29, 22, 30, 23, 31,
-  16, 24, 17, 25, 18, 26, 19, 27,
-  4, 12, 5, 13, 6, 14, 7, 15
-};
-#else
- static const int sensorMap[] = {
   7, 4, 5, 6, 2, 1, 3, 0,
   31, 28, 29, 30, 26, 25, 27, 24,
   23, 20, 21, 22, 18, 17, 19, 16,
   15, 12, 13, 14, 10, 9, 11, 8
+};
+#elif defined(OPENITHM_FULL2_0_SIDE)
+static const int sensorMap[] = {
+  0, 3, 2, 1, 5, 6, 4, 7,
+  24, 27, 26, 25, 29, 30, 28, 31,
+  16, 19, 18, 17, 21, 22, 20, 23,
+  8, 11, 10, 9, 13, 14, 12, 15
+};
+#else
+ static const int sensorMap[] = {
+ 
+  11, 3, 10, 2, 9, 1, 8, 0,
+  31, 23, 30, 22, 29, 21, 28, 20,
+  27, 19, 26, 18, 25, 17, 24, 16,
+  15, 7, 14, 6, 13, 5, 12, 4
 };     
 #endif
 #endif

--- a/Firmware/OpeNITHM/Config.h
+++ b/Firmware/OpeNITHM/Config.h
@@ -13,8 +13,9 @@
 // #define OPENITHM_V1_1   // Version 1.1 (v1.1 on board under logo)
 // #define OPENITHM_V2_0   // Version 2.0 (v2.0 in upper left of board)
 // #define OPENITHM_V2_1   // Version 2.1 (v2.1 in upper left of board)
-// #define OPENITHM_FULL_V1_0 // Version 1.0 of the fully integrated board with touch sensors (Not common)
- #define OPENITHM_FULL_V2_0 // Version 2.0 of the fully integrated board with touch sensors (Integrated USB C Port)
+// #define OPENITHM_FULL_V1_0 // Version 1.0 of the fully integrated board with touch sensors (Not common, prototype)
+// #define OPENITHM_FULL2_0_SIDE // Version 2.0 of the fully integrated board with touch sensors (Uses extra LED board, FULL2.0_SIDE under logo)
+// #define OPENITHM_FULL2_0_UP // Version 2.0 of the fully integrated board with touch sensors (RGB chips on the main board, FULL2.0_UP under logo)
 
 // Uncomment this line if your IR sensors will be used in analog mode
 // ** OPENITHM_V1_1 AND ABOVE SHOULD ENABLE THIS OPTION **
@@ -73,24 +74,20 @@
 #define USB
 
 // Spit out errors for board definitions
-#if (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0) + defined(OPENITHM_FULL_V2_0)) == 0
+#if (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0) + defined(OPENITHM_FULL2_0_SIDE) + defined(OPENITHM_FULL2_0_UP)) == 0
 #error "Must define ONE Teensy board in Config.h"
-#elif (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0) + defined(OPENITHM_FULL_V2_0)) > 1
+#elif (defined(OPENITHM_V1_0) + defined(OPENITHM_V1_1) + defined(OPENITHM_V2_0) + defined(OPENITHM_V2_1) + defined(OPENITHM_FULL_V1_0) + defined(OPENITHM_FULL2_0_SIDE) + defined(OPENITHM_FULL2_0_UP)) > 1
 #error "Cannot define multiple Teensy boards in Config.h"
 #endif
 #endif
 
-#if (defined(OPENITHM_V2_0) || defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL_V2_0))
+#if (defined(OPENITHM_V2_0) || defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP))
 #define NUM_SENSORS  32
 #else
 #define NUM_SENSORS  16
 #endif
 
-#if (defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL_V2_0))
-#define ALT_TOUCHKEY_ORDER
-#endif
-
-#if defined(OPENITHM_FULL_V2_0)
+#if (defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP))
 #define ALTERNATING_AIR
 #endif
 

--- a/Firmware/OpeNITHM/PinConfig.h
+++ b/Firmware/OpeNITHM/PinConfig.h
@@ -24,7 +24,7 @@
 #define MUX_0 4
 #define MUX_1 3
 #define MUX_2 2
-#elif defined(OPENITHM_FULL_V2_0)
+#elif defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP)
 #define MUX_0 7
 #define MUX_1 6
 #define MUX_2 2
@@ -43,7 +43,7 @@
 #define LED_0 8
 #define LED_1 7
 #define LED_2 6
-#elif defined(OPENITHM_FULL_V2_0)
+#elif defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP)
 #define LED_0 14
 #define LED_1 13
 #define LED_2 15
@@ -76,7 +76,7 @@
 #define AIR_SENSOR_3_PIN 19
 #define AIR_SENSOR_4_PIN 21
 #define AIR_SENSOR_5_PIN 23
-#elif defined(OPENITHM_FULL_V2_0)
+#elif defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP)
 #define AIR_SENSOR_0_PIN 18
 #define AIR_SENSOR_1_PIN 23
 #define AIR_SENSOR_2_PIN 19
@@ -108,7 +108,7 @@
 #define TOUCH_1 15
 #define TOUCH_2 16
 #define TOUCH_3 0
-#elif defined(OPENITHM_FULL_V2_0)
+#elif defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP)
 #define TOUCH_0 0
 #define TOUCH_1 4
 #define TOUCH_2 3
@@ -132,7 +132,7 @@
     #else
        #define RGBPIN 11
     #endif
-#elif defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL_V2_0)
+#elif defined(OPENITHM_V2_1) || defined(OPENITHM_FULL_V1_0) || defined(OPENITHM_FULL2_0_SIDE) || defined(OPENITHM_FULL2_0_UP)
   #define RGBPIN 5
 #endif
 


### PR DESCRIPTION
Since the big board is now two versions, I added code to support them both separately. Unfortunately I needed to add a new sensorMap[] for the new board, so I reverted the "ALT_TOUCHKEY_ORDER" define back to the way it was before, and now it just uses the board define instead.